### PR TITLE
Introduce SIGKILL to ensure process has terminated after MAXWAIT

### DIFF
--- a/debian/collectd-core.collectd.default
+++ b/debian/collectd-core.collectd.default
@@ -12,6 +12,10 @@ USE_COLLECTDMON=1
 # default: 30
 MAXWAIT=30
 
+# try a terminal kill -9 if the process refuses to shut down
+# default: 0
+declare -i USE_SIGKILL=1
+
 # 0: do not enable core-files, 1: enable core-files ... if collectd crashes
 # default: 0
 ENABLE_COREFILES=0


### PR DESCRIPTION
This PR enables the init script to SIGKILL the process group of the service after MAXWAIT has expired. The feature is set in `/etc/default/collectd` and enabled by default:

```
declare -i USE_SIGKILL=1
```
