### PR TITLE
TODO file is not part of collectd any more

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -263,7 +263,7 @@ binary-indep: install-indep
 	dh_testdir
 	dh_testroot
 	dh_installchangelogs -i ChangeLog
-	dh_installdocs -A -i debian/README.Debian AUTHORS README TODO
+	dh_installdocs -A -i debian/README.Debian AUTHORS README
 	dh_installexamples -i contrib/examples/myplugin.c \
 		contrib/examples/MyPlugin.pm
 	dh_compress -i -Xexamples/
@@ -277,7 +277,7 @@ binary-arch: build install-arch
 	dh_testdir
 	dh_testroot
 	dh_installchangelogs -a ChangeLog
-	dh_installdocs -A -a debian/README.Debian AUTHORS README TODO
+	dh_installdocs -A -a debian/README.Debian AUTHORS README
 	dh_installdocs -a debian/NEWS.Debian debian/README.Debian.plugins
 	dh_installexamples -a contrib/collectd2html.pl contrib/collection.cgi \
 		contrib/collection3/ contrib/php-collection/ \


### PR DESCRIPTION
TODO file is not part of collectd any more

https://github.com/collectd/collectd/commit/dcb4470c37cb8da1fccc9aa32e3671548b16f17b Remove TODO, it's way out of date (https://github.com/collectd/collectd/pull/1892)
