### PR TITLE
control: strict dependency between collectd and collectd-core

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -226,7 +226,7 @@ Description: statistics collection and monitoring daemon (core system)
 
 Package: collectd
 Architecture: any
-Depends: collectd-core, ${shlibs:Depends}, ${misc:Depends}
+Depends: collectd-core (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Recommends: ${shlibs:Recommends}, default-jre-headless
 Description: statistics collection and monitoring daemon
  collectd is a small daemon which collects system information periodically and


### PR DESCRIPTION
There has been several confused reports from users, which believed they
used version X but were in fact running version Y, as they somehow
managed to upgrade collectd without upgrading collectd-core alongside.

This drops some flexibility but makes the upgrade process less
surprising.