### PR TITLE
control: Have a stricter dependency between collectd and collectd-core.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -226,7 +226,8 @@ Description: statistics collection and monitoring daemon (core system)
 
 Package: collectd
 Architecture: any
-Depends: collectd-core, ${shlibs:Depends}, ${misc:Depends}
+Depends: collectd-core (>= ${source:Version}), collectd-core (<< 6~),
+ ${shlibs:Depends}, ${misc:Depends}
 Recommends: ${shlibs:Recommends}, default-jre-headless
 Description: statistics collection and monitoring daemon
  collectd is a small daemon which collects system information periodically and


### PR DESCRIPTION
That is, depend on greater or equal the `collectd` version but less than the
next major version.

The `collectd` package provides config files which are expected to be
backward compatible (across the same major version) but may depend on new
features in the current (at the time) minor version.